### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: python
 
 python:
   - "2.7"
+  - "3.6"
 
 install:
   - "pip install ."
   - "pip install flake8"
 
 script:
-  - flake8 *.py
+  - flake8 .
   - python test_change_utils.py

--- a/example/example1.py
+++ b/example/example1.py
@@ -6,9 +6,14 @@
 """
 from __future__ import print_function
 
-from pysnow_change_epfl.change_utils import check_sciper, check_pwd, \
-                                            get_changelog_info, \
-                                            create_change
+from pysnow_change_epfl.change_utils import (check_sciper, check_pwd,
+                                             get_changelog_info,
+                                             create_change)
+
+try:
+    raw_input
+except NameError:  # raw_input() was removed in Python 3
+    raw_input = input
 
 # Verification before create change
 try:

--- a/example/example1.py
+++ b/example/example1.py
@@ -4,6 +4,7 @@
 """
 (c) ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018.
 """
+from __future__ import print_function
 
 from pysnow_change_epfl.change_utils import check_sciper, check_pwd, \
                                             get_changelog_info, \
@@ -18,20 +19,20 @@ try:
     # with ### and the version number X.Y.Z should precede the date! **
     version_number, description, impact_category = get_changelog_info(
         '<path_to_CHANGELOG.md>')
-    print "Version: {}".format(version_number)
-    print "List of changes: \n{}".format(description)
+    print("Version: {}".format(version_number))
+    print("List of changes: \n{}".format(description))
     rep = raw_input(
         "Is the version and description correct? [type 'yes' to confirm] : ")
     if rep != 'yes':
-        print "create change canceled."
+        print("create change canceled.")
         exit(1)
 except Exception as exc:
-    print exc
+    print(exc)
     exit(1)
 
 # Create change
-print create_change(service_id='SVC0016',
+print(create_change(service_id='SVC0016',
                     snow_group='SI_NEWS',
                     impact_category=impact_category,
                     short_description="Actu - {}".format(version_number),
-                    description=description)
+                    description=description))


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.